### PR TITLE
Add Flask web app for US drug data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Drug Info Web App
+
+This Flask application provides basic information about drug-related crime rates,
+deaths from drug abuse, and fetches recent news articles related to drugs in the
+United States. Users can post updates that are stored locally in `data.json`.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. (Optional) Set a `NEWS_API_KEY` environment variable to fetch headlines from
+   [NewsAPI.org](https://newsapi.org/).
+3. Run the server:
+   ```bash
+   python run.py
+   ```
+
+## Endpoints
+
+- `GET /api/data` – Get stored statistics and updates.
+- `POST /api/data` – Post JSON `{ "update": "text" }` to append an update.
+- `GET /api/news` – Fetch current news headlines about drugs.
+
+This project is a simple example and does not include persistent storage or
+authentication. It is intended as a demo for updating and retrieving recent
+information about drug crime and abuse in the US.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,5 @@
+from flask import Flask
+
+app = Flask(__name__)
+
+from . import routes  # noqa: E402, F401

--- a/app/data.json
+++ b/app/data.json
@@ -1,0 +1,5 @@
+{
+  "drug_crime_rate": "Unknown",
+  "drug_abuse_deaths": "Unknown",
+  "updates": []
+}

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,55 @@
+import os
+import json
+from flask import request, jsonify
+import requests
+
+from . import app
+
+DATA_FILE = os.path.join(os.path.dirname(__file__), 'data.json')
+
+
+def load_data():
+    if os.path.exists(DATA_FILE):
+        with open(DATA_FILE, 'r') as f:
+            return json.load(f)
+    return {
+        "drug_crime_rate": "N/A",
+        "drug_abuse_deaths": "N/A",
+        "updates": []
+    }
+
+
+def save_data(data):
+    with open(DATA_FILE, 'w') as f:
+        json.dump(data, f, indent=2)
+
+
+@app.route('/api/data', methods=['GET'])
+def get_data():
+    data = load_data()
+    return jsonify(data)
+
+
+@app.route('/api/data', methods=['POST'])
+def update_data():
+    data = load_data()
+    new_update = request.json.get('update')
+    if new_update:
+        data['updates'].append(new_update)
+        save_data(data)
+    return jsonify(data)
+
+
+@app.route('/api/news')
+def get_news():
+    api_key = os.environ.get('NEWS_API_KEY')
+    if not api_key:
+        return jsonify({"error": "NEWS_API_KEY not set"}), 400
+    resp = requests.get(
+        'https://newsapi.org/v2/top-headlines',
+        params={'category': 'health', 'apiKey': api_key, 'q': 'drug'},
+        timeout=10
+    )
+    if resp.ok:
+        return jsonify(resp.json())
+    return jsonify({"error": "failed to fetch news"}), 500

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests

--- a/run.py
+++ b/run.py
@@ -1,0 +1,4 @@
+from app import app
+
+if __name__ == '__main__':
+    app.run(debug=True, host='0.0.0.0')


### PR DESCRIPTION
## Summary
- build a simple Flask-based web app
- allow updates to stored data
- fetch recent drug-related news
- provide example data and setup instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684339f63ccc832aaa5d8233116af2ed